### PR TITLE
Fix libtool link error "line 6000: cd: no: No such file or directory"

### DIFF
--- a/m4/httpd.m4
+++ b/m4/httpd.m4
@@ -1,17 +1,38 @@
 
 AC_DEFUN([AC_CHECK_HTTPD],
 [
-ac_httpd="/usr/sbin/httpd /usr/local/sbin/httpd /usr/sbin/httpd2 /usr/local/sbin/httpd2 /usr/sbin/apache /usr/local/sbin/apache /usr/sbin/apache2 /usr/local/sbin/apache2"
-for i in $ac_httpd; do
-    if test -e $i
-    then
-        $1="$i"
-        HTTPD_SERVER="$i"
-    fi
-done
+AC_MSG_NOTICE([Trying to find some web servers, provides the virtual package "httpd"])
+HTTPD=no
+AC_PATH_PROGS([HTTPD], [httpd httpd2 apachectl apache2ctl], [no], 
+		[$PATH$PATH_SEPARATOR/usr/local/sbin$PATH_SEPARATOR]dnl
+     [/usr/sbin])
 
-HTTPD_ROOT=`$HTTPD_SERVER -V |grep HTTPD_ROOT|sed -e 's/"//g'|sed -e 's/=/ /g'|sed -e 's/-D HTTPD_ROOT//g'|sed -e 's/\n//g'|sed -e 's/ //g'`
-SERVER_CONFIG_FILE=$HTTPD_ROOT/`$HTTPD_SERVER -V |grep SERVER_CONFIG_FILE|sed -e 's/"//g'|sed -e 's/=/ /g'|sed -e 's/-D SERVER_CONFIG_FILE//g'|sed -e 's/\n//g'|sed -e 's/ //g'`
+if test  "x$HTTPD" = "xno"; then
+	AC_MSG_ERROR([httpd not found in $PATH$PATH_SEPARATOR/usr/local/sbin$PATH_SEPARATOR/usr/sbin])
+else
+	$1="$HTTPD"
+	HTTPD_SERVER="$HTTPD"
+fi
+
+# This code mostly copied from GNU macro AX_PROG_HTTPD
+HTTPD_ROOT=`$HTTPD_SERVER -V | grep HTTPD_ROOT | sed 's/^.*HTTPD_ROOT[[[:blank:]]]*=[[[:blank:]]]*"\(.*\)"$/\1/'`
+SERVER_CONFIG_FILE=`$HTTPD_SERVER -V | grep SERVER_CONFIG_FILE | sed 's/^.*SERVER_CONFIG_FILE[[[:blank:]]]*=[[[:blank:]]]*"\(.*\)"$/\1/'`
+if echo $SERVER_CONFIG_FILE | grep ^[[^/]] > /dev/null; then
+        SERVER_CONFIG_FILE=$HTTPD_ROOT/$SERVER_CONFIG_FILE
+fi
+SERVER_ROOT_PATTERN='^[[[:blank:]]]*ServerRoot[[[:blank:]]][[[:blank:]]]*"\([[^"]]*\)"$'
+HTTPD_USER_PATTERN='^User[[[:blank:]]][[[:blank:]]]*\([[^[:blank:]]][[^[:blank:]]]*\)$'
+HTTPD_GROUP_PATTERN='^Group[[[:blank:]]][[[:blank:]]]*\([[^[:blank:]]][[^[:blank:]]]*\)$'
+DOCUMENT_ROOT_PATTERN='^[[[:blank:]]]*DocumentRoot[[[:blank:]]][[[:blank:]]]*"\([[^"]]*\)"$'
+SCRIPT_ALIAS_PATTERN='^[[[:blank:]]]*ScriptAlias[[[:blank:]]][[[:blank:]]]*[[^[:blank:]]][[^[:blank:]]]*[[[:blank:]]][[[:blank:]]]*"\([[^"]]*\)"$'
+AC_CHECK_FILE($SERVER_CONFIG_FILE,
+        [HTTPD_SERVER_ROOT=`grep $SERVER_ROOT_PATTERN $SERVER_CONFIG_FILE | head -n 1 | sed "s/$SERVER_ROOT_PATTERN/\1/" | sed s/[[/]]$//`;
+                HTTPD_USER=`grep $HTTPD_USER_PATTERN $SERVER_CONFIG_FILE | sed "s/$HTTPD_USER_PATTERN/\1/"`;
+                HTTPD_GROUP=`grep $HTTPD_GROUP_PATTERN $SERVER_CONFIG_FILE | sed "s/$HTTPD_GROUP_PATTERN/\1/"`;
+                HTTPD_DOC_HOME=`grep $DOCUMENT_ROOT_PATTERN $SERVER_CONFIG_FILE | head -n 1 | sed "s/$DOCUMENT_ROOT_PATTERN/\1/" | sed s/[[/]]$//`;
+                HTTPD_SCRIPT_HOME=`grep $SCRIPT_ALIAS_PATTERN $SERVER_CONFIG_FILE | head -n 1 | sed "s/$SCRIPT_ALIAS_PATTERN/\1/" | sed s/[[/]]$//`],
+        AC_MSG_ERROR([httpd server-config-file (detected as $SERVER_CONFIG_FILE by $HTTPD_SERVER -V) cannot be found]))dnl
+
 altlinux5=`grep -qi  "ALT Linux 5" /etc/altlinux-release &>/dev/null && echo 1 || echo 0`
 altlinux4=`grep -qi  "ALT Linux 4" /etc/altlinux-release &>/dev/null && echo 1 || echo 0`
 debian=`test -e /etc/debian_version && echo 1 || echo 0`
@@ -26,7 +47,7 @@ else
     else
 	if [[ $debian -eq 1 ]]
 	then
-	    HTTPD_INCLUDE=$HTTPD_ROOT/conf.d/
+	    HTTPD_INCLUDE=$HTTPD_ROOT/conf-available/
 	else
 	    HTTPD_INCLUDE=$HTTPD_ROOT/`grep ^"Include " $SERVER_CONFIG_FILE |sed -e 's|/.*$ |/|g'|sed -e 's/Include//g'|sed -e 's, ,,g'| sed -e 's/[[^\/]]*$//g'`
 	fi

--- a/m4/mysql.m4
+++ b/m4/mysql.m4
@@ -21,7 +21,8 @@ if test "x$ac_mysql_includes" = "x"; then
 fi
 
 if test "x$ac_mysql_libraries" = "x"; then
-  ac_mysql_libraries="/usr/lib64/mysql /usr/local/mysql/lib/mysql /usr/local/lib/mysql /usr/lib/mysql /usr/local/lib /usr/lib"
+  ac_mysql_libraries="/usr/lib64/mysql /usr/local/mysql/lib/mysql /usr/local/lib/mysql /usr/lib/mysql /usr/local/lib /usr/lib \
+			/usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu"
 fi
 
 if test "$ac_use_mysql" = "no"; then

--- a/m4/pq.m4
+++ b/m4/pq.m4
@@ -21,7 +21,7 @@ if test "x$ac_pq_includes" = "x"; then
 fi
 
 if test "x$ac_pq_libraries" = "x"; then
-  ac_pq_libraries="/usr/local/lib /usr/lib64 /usr/lib"
+  ac_pq_libraries="/usr/local/lib /usr/lib64 /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu"
 fi
 
 if test "$ac_use_pq" = "no"; then

--- a/m4/unixodbc.m4
+++ b/m4/unixodbc.m4
@@ -21,7 +21,7 @@ if test x"$ac_unixodbc_includes" = "x"; then
 fi
 
 if test x"$ac_unixodbc_libraries" = "x"; then
-  ac_unixodbc_libraries="/usr/lib64 /usr/local/lib /usr/lib"
+  ac_unixodbc_libraries="/usr/lib64 /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu"
 fi
 
 if test "$ac_use_unixodbc" = "no"; then


### PR DESCRIPTION
При сборке SAMS2 в Debian(Ubuntu) появляется ошибка 
`/bin/bash ../libtool  --tag=CXX   --mode=link g++ -Wall -g -O2 -I/usr/include  -Lno -o samsparser samsparser.o debug.o .... samsldap.o  -lldap  -lpcre -lmysqlclient -ldl`
`../libtool: line 6000: cd: no: No such file or directory`
`libtool: link: cannot determine absolute directory name of ```no'`
`Makefile:503: ошибка выполнения рецепта для цели «samsparser»`
`make[2]: *** [samsparser] Ошибка 1` 

По-моему,  проблема в том, что изменились пути к библиотекам MySQL, PostgreSQL и UnixODBC, а макросы об этом не знают. 