### PR TITLE
Added Debian lib path in DB macro files. It`s fixing (I hope) libtool link error  "line 6000: cd: no: No such file or directory"

### DIFF
--- a/m4/mysql.m4
+++ b/m4/mysql.m4
@@ -21,7 +21,8 @@ if test "x$ac_mysql_includes" = "x"; then
 fi
 
 if test "x$ac_mysql_libraries" = "x"; then
-  ac_mysql_libraries="/usr/lib64/mysql /usr/local/mysql/lib/mysql /usr/local/lib/mysql /usr/lib/mysql /usr/local/lib /usr/lib"
+  ac_mysql_libraries="/usr/lib64/mysql /usr/local/mysql/lib/mysql /usr/local/lib/mysql /usr/lib/mysql /usr/local/lib /usr/lib \
+			/usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu"
 fi
 
 if test "$ac_use_mysql" = "no"; then

--- a/m4/pq.m4
+++ b/m4/pq.m4
@@ -21,7 +21,7 @@ if test "x$ac_pq_includes" = "x"; then
 fi
 
 if test "x$ac_pq_libraries" = "x"; then
-  ac_pq_libraries="/usr/local/lib /usr/lib64 /usr/lib"
+  ac_pq_libraries="/usr/local/lib /usr/lib64 /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu"
 fi
 
 if test "$ac_use_pq" = "no"; then

--- a/m4/unixodbc.m4
+++ b/m4/unixodbc.m4
@@ -21,7 +21,7 @@ if test x"$ac_unixodbc_includes" = "x"; then
 fi
 
 if test x"$ac_unixodbc_libraries" = "x"; then
-  ac_unixodbc_libraries="/usr/lib64 /usr/local/lib /usr/lib"
+  ac_unixodbc_libraries="/usr/lib64 /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu"
 fi
 
 if test "$ac_use_unixodbc" = "no"; then


### PR DESCRIPTION
При сборке SAMS2 в Debian(Ubuntu) появляется ошибка 
`/bin/bash ../libtool  --tag=CXX   --mode=link g++ -Wall -g -O2 -I/usr/include  -Lno -o samsparser samsparser.o debug.o .... samsldap.o  -lldap  -lpcre -lmysqlclient -ldl`
`../libtool: line 6000: cd: no: No such file or directory`
`libtool: link: cannot determine absolute directory name of```no'`
`Makefile:503: ошибка выполнения рецепта для цели «samsparser»`
`make[2]: *** [samsparser] Ошибка 1` 

По-моему,  проблема в том, что изменились пути к библиотекам MySQL, PostgreSQL и UnixODBC, а макросам об этом не известно. 
